### PR TITLE
Don't reset user in store on generic server errors

### DIFF
--- a/src/reducer/auth.test.ts
+++ b/src/reducer/auth.test.ts
@@ -1,0 +1,22 @@
+import reducer, { errorLoaded, loginSuccess, logOut } from './auth';
+import { User } from './types';
+
+const user: User = { id: 1, name: 'test', jwt: 'test-jwt' };
+
+describe('auth reducer', () => {
+  it('keeps the user when a server error is loaded', () => {
+    expect(reducer(user, errorLoaded('something went wrong'))).toEqual(user);
+  });
+
+  it('stores the user on login success', () => {
+    expect(reducer(null, loginSuccess(user))).toEqual(user);
+  });
+
+  it('clears the user and tokens on logout', () => {
+    localStorage.setItem('jwt', 'test-jwt');
+    localStorage.setItem('refreshToken', 'test-refresh');
+    expect(reducer(user, logOut())).toBeNull();
+    expect(localStorage.getItem('jwt')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+  });
+});

--- a/src/reducer/auth.ts
+++ b/src/reducer/auth.ts
@@ -37,7 +37,6 @@ export default createReducer<User | null>(null, (builder) =>
       localStorage.removeItem('refreshToken');
       return null;
     })
-    .addCase(errorLoaded, () => null)
     .addCase(InternalMessageTypes.LOGIN_OR_SIGNUP_ERROR, () => {
       localStorage.removeItem('jwt');
       return null;


### PR DESCRIPTION
Previously, the auth reducer reset the user to `null` on every `ERROR` action, so any failed request (joining a room, fetching a game, a transient network blip) made the UI treat a logged-in user as logged out until a page reload.

After this change generic server errors no longer touch the user. Genuine auth failures still log out: `errorFromServer` dispatches `LOGOUT` for expired tokens, and the login/signup error path clears its own state.

Adds a reducer test covering both cases.