### PR TITLE
Keep stored tokens on transient errors during profile fetch

### DIFF
--- a/src/thunkActions/authorization.test.ts
+++ b/src/thunkActions/authorization.test.ts
@@ -1,0 +1,197 @@
+import superagent from 'superagent';
+import { InternalMessageTypes } from '../constants/internalMessageTypes';
+import { getProfileFetch } from './authorization';
+
+jest.mock('superagent');
+
+const mockedGet = superagent.get as jest.Mock;
+
+const profileRequest = (result: {
+  resolve?: object;
+  reject?: object;
+}): { set: jest.Mock } => ({
+  set: result.resolve
+    ? jest.fn().mockResolvedValue(result.resolve)
+    : jest.fn().mockRejectedValue(result.reject),
+});
+
+// an expired access token comes back as a superagent 401 whose body message
+// is TokenExpiredError; errorFromServer turns exactly that into a logOut
+const expiredTokenError = {
+  status: 401,
+  response: { body: { message: 'TokenExpiredError: jwt expired' } },
+};
+
+// dispatch that records actions and executes nested thunks, so side effects
+// like errorFromServer -> logOut actually run and can be asserted on
+const runThunk = async () => {
+  const dispatched: Array<{ type?: string } | unknown> = [];
+  const getState = () => ({ translation: { locale: 'en_US' } });
+  const dispatch = (action: unknown): unknown => {
+    dispatched.push(action);
+    if (typeof action === 'function') {
+      return (action as (d: typeof dispatch, g: typeof getState) => unknown)(
+        dispatch,
+        getState
+      );
+    }
+    return action;
+  };
+  await (
+    getProfileFetch('old-jwt') as unknown as (
+      dispatch: (action: unknown) => unknown
+    ) => Promise<void>
+  )(dispatch);
+  return dispatched;
+};
+
+const loggedOut = (dispatched: Array<{ type?: string } | unknown>) =>
+  dispatched.some(
+    (a) => (a as { type?: string })?.type === InternalMessageTypes.LOGOUT
+  );
+
+describe('getProfileFetch', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    localStorage.setItem('jwt', 'old-jwt');
+    localStorage.setItem('refreshToken', 'old-refresh');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    delete (global as { fetch?: unknown }).fetch;
+  });
+
+  it('keeps tokens when the profile request fails with a network error', async () => {
+    mockedGet.mockReturnValue(
+      profileRequest({ reject: { code: 'ECONNREFUSED' } })
+    );
+
+    await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBe('old-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('old-refresh');
+  });
+
+  it('keeps tokens on a non-401 profile error and does not attempt a refresh', async () => {
+    mockedGet.mockReturnValue(profileRequest({ reject: { status: 403 } }));
+    const fetchMock = jest.fn();
+    (global as { fetch?: unknown }).fetch = fetchMock;
+
+    const dispatched = await runThunk();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem('jwt')).toBe('old-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('old-refresh');
+    expect(loggedOut(dispatched)).toBe(false);
+  });
+
+  it('clears tokens when the token and its refresh are both refused', async () => {
+    mockedGet.mockReturnValue(profileRequest({ reject: expiredTokenError }));
+    (global as { fetch?: unknown }).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 401 });
+
+    await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+  });
+
+  it('keeps tokens and does not log out when refresh is down (5xx) after an expired-token 401', async () => {
+    mockedGet.mockReturnValue(profileRequest({ reject: expiredTokenError }));
+    (global as { fetch?: unknown }).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 503 });
+
+    const dispatched = await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBe('old-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('old-refresh');
+    expect(loggedOut(dispatched)).toBe(false);
+  });
+
+  it('keeps tokens when the refresh endpoint rate-limits (429)', async () => {
+    mockedGet.mockReturnValue(profileRequest({ reject: expiredTokenError }));
+    (global as { fetch?: unknown }).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 429 });
+
+    const dispatched = await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBe('old-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('old-refresh');
+    expect(loggedOut(dispatched)).toBe(false);
+  });
+
+  it('keeps tokens when the refresh request throws (network error)', async () => {
+    mockedGet.mockReturnValue(profileRequest({ reject: expiredTokenError }));
+    (global as { fetch?: unknown }).fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('network down'));
+
+    const dispatched = await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBe('old-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('old-refresh');
+    expect(loggedOut(dispatched)).toBe(false);
+  });
+
+  it('keeps refreshed tokens when the retry fails transiently', async () => {
+    mockedGet
+      .mockReturnValueOnce(profileRequest({ reject: expiredTokenError }))
+      .mockReturnValueOnce(profileRequest({ reject: { code: 'ECONNRESET' } }));
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        payload: { jwt: 'new-jwt', refreshToken: 'new-refresh' },
+      }),
+    });
+
+    await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBe('new-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('new-refresh');
+  });
+
+  it('updates the user when refresh and retry succeed', async () => {
+    const action = {
+      type: 'LOGIN_SUCCESS',
+      payload: { id: 1, name: 'test', jwt: 'new-jwt' },
+    };
+    mockedGet
+      .mockReturnValueOnce(profileRequest({ reject: expiredTokenError }))
+      .mockReturnValueOnce(
+        profileRequest({ resolve: { text: JSON.stringify(action) } })
+      );
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        payload: { jwt: 'new-jwt', refreshToken: 'new-refresh' },
+      }),
+    });
+
+    const dispatched = await runThunk();
+
+    expect(dispatched).toContainEqual(action);
+    expect(localStorage.getItem('jwt')).toBe('new-jwt');
+    expect(localStorage.getItem('refreshToken')).toBe('new-refresh');
+  });
+
+  it('clears tokens when the retry is rejected with 401 again', async () => {
+    mockedGet
+      .mockReturnValueOnce(profileRequest({ reject: expiredTokenError }))
+      .mockReturnValueOnce(profileRequest({ reject: { status: 401 } }));
+    (global as { fetch?: unknown }).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        payload: { jwt: 'new-jwt', refreshToken: 'new-refresh' },
+      }),
+    });
+
+    await runThunk();
+
+    expect(localStorage.getItem('jwt')).toBeNull();
+    expect(localStorage.getItem('refreshToken')).toBeNull();
+  });
+});

--- a/src/thunkActions/authorization.ts
+++ b/src/thunkActions/authorization.ts
@@ -82,26 +82,52 @@ export const loginSignupFunction =
     }
   };
 
-export async function refreshTokens(): Promise<{
-  jwt: string;
-  refreshToken: string;
-} | null> {
+type RefreshOutcome =
+  | { status: 'success'; jwt: string; refreshToken: string }
+  | { status: 'rejected' } // the refresh token itself was refused
+  | { status: 'error' }; // transient failure, the token may still be valid
+
+async function requestTokenRefresh(): Promise<RefreshOutcome> {
   const refreshToken = localStorage.getItem('refreshToken');
-  if (!refreshToken) return null;
+  if (!refreshToken) return { status: 'rejected' };
   try {
     const response = await fetch(`${baseUrl}/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refreshToken }),
     });
-    if (!response.ok) return null;
-    const data = await response.json();
-    localStorage.setItem('jwt', data.payload.jwt);
-    localStorage.setItem('refreshToken', data.payload.refreshToken);
-    return { jwt: data.payload.jwt, refreshToken: data.payload.refreshToken };
+    if (response.ok) {
+      const data = await response.json();
+      localStorage.setItem('jwt', data.payload.jwt);
+      localStorage.setItem('refreshToken', data.payload.refreshToken);
+      return {
+        status: 'success',
+        jwt: data.payload.jwt,
+        refreshToken: data.payload.refreshToken,
+      };
+    }
+    // 5xx, request timeout and rate limiting are retryable and the refresh
+    // token may still be valid, so treat them as transient; any other 4xx
+    // means the refresh token itself was refused
+    return response.status >= 500 ||
+      response.status === 408 ||
+      response.status === 429
+      ? { status: 'error' }
+      : { status: 'rejected' };
   } catch {
-    return null;
+    // network failure: transient, keep the token for the next attempt
+    return { status: 'error' };
   }
+}
+
+export async function refreshTokens(): Promise<{
+  jwt: string;
+  refreshToken: string;
+} | null> {
+  const outcome = await requestTokenRefresh();
+  return outcome.status === 'success'
+    ? { jwt: outcome.jwt, refreshToken: outcome.refreshToken }
+    : null;
 }
 
 export const getProfileFetch =
@@ -117,24 +143,43 @@ export const getProfileFetch =
         dispatch(action);
       } catch (error: any) {
         if (error?.status === 401) {
-          const refreshed = await refreshTokens();
-          if (refreshed) {
+          const outcome = await requestTokenRefresh();
+          if (outcome.status === 'success') {
             try {
               const retryResponse = await superagent
                 .get(url)
-                .set('Authorization', `Bearer ${refreshed.jwt}`);
+                .set('Authorization', `Bearer ${outcome.jwt}`);
               const action: LoginSuccessAction = JSON.parse(retryResponse.text);
               dispatch(action);
               return;
-            } catch (retryError) {
+            } catch (retryError: any) {
               dispatch(errorFromServer(retryError, 'getProfileFetch'));
+              if (retryError?.status !== 401) {
+                // a non-401 failure after a successful refresh (network, 5xx
+                // or a 4xx unrelated to the token): the refreshed credentials
+                // were not rejected, so keep them
+                return;
+              }
+              // a freshly refreshed token was still rejected: session is gone
             }
+          } else if (outcome.status === 'error') {
+            // the refresh endpoint was temporarily unreachable, the refresh
+            // token may still be valid: keep tokens and retry on next launch.
+            // deliberately no errorFromServer here: the original error is the
+            // expired-token 401, which errorFromServer turns into a logOut
+            // that would wipe the very tokens we are trying to preserve
+            return;
           }
+          // the token and its refresh were both refused: clear credentials
+          localStorage.removeItem('jwt');
+          localStorage.removeItem('refreshToken');
         } else {
+          // any non-401 profile failure (network, 5xx, or a 4xx such as
+          // 403/404): the server did not reject the stored credentials, so
+          // keep them and let the next launch retry with the same session.
+          // only an explicit 401 (handled above) discards credentials
           dispatch(errorFromServer(error, 'getProfileFetch'));
         }
-        localStorage.removeItem('jwt');
-        localStorage.removeItem('refreshToken');
       }
     }
   };


### PR DESCRIPTION
Previously, `getProfileFetch` removed both `jwt` and `refreshToken` from `localStorage` on any failure, including network errors and 5xx while the backend was briefly unreachable at startup, permanently logging the user out.

After this change tokens are cleared only when the server explicitly rejects the credentials:

- a 401 on the profile followed by a refused refresh token, or
- a 401 on the retry with a freshly refreshed token.

Transient refresh failures (network error, 5xx, 408, 429 from `/refresh`) keep the tokens so the next launch can retry with the same session. A non-401 profile error (e.g. 403/404) also keeps the tokens, since it does not indicate the stored credentials are invalid. The expired-token 401 is deliberately not forwarded to `errorFromServer` on the transient path, since it would trigger a `logOut` that wipes the very tokens being preserved.

Adds tests, including one that executes nested thunks to prove no `LOGOUT` is dispatched on a transient refresh failure.

Note: the socket `TOKEN_EXPIRED` path in `store.ts` has the same transient-wipe behaviour and is left for a separate change.